### PR TITLE
Add link shortener back to Mathograms

### DIFF
--- a/public/js/compose.js
+++ b/public/js/compose.js
@@ -39,7 +39,7 @@
     return urlBase.concat('?message=',message,'&from=',from,'&graph=',graphName);
   };
 
-  //this is called once we have a short url from the google url-shortener
+  //this is called once we have a short url from the TinyURL
   var shareCallback = function(shareLink){
     $shareLink.val(shareLink);
     var tweetUrl = "https://twitter.com/intent/tweet?text="
@@ -52,11 +52,12 @@
     showShare();
   };
 
-  //TODO: hook up a new link shortener!
   var share = function(){
     $body.addClass('is-loading');
     var longUrl = getLongUrl();
-    shareCallback(longUrl);
+
+    // shorten longUrl using TinyURL API
+    $.get("https://tinyurl.com/api-create.php?url=" + encodeURIComponent(longUrl)).done(shareCallback);
   };
 
   //this is the code that interacts with the graphpaper

--- a/public/js/compose.js
+++ b/public/js/compose.js
@@ -57,7 +57,12 @@
     var longUrl = getLongUrl();
 
     // shorten longUrl using TinyURL API
-    $.get("https://tinyurl.com/api-create.php?url=" + encodeURIComponent(longUrl)).done(shareCallback);
+    $.get("https://tinyurl.com/api-create.php?url=" + encodeURIComponent(longUrl))
+      .done(shareCallback)
+      .fail(function () {
+        // share longUrl if TinyURL API call fails
+        shareCallback(longUrl);
+      });
   };
 
   //this is the code that interacts with the graphpaper


### PR DESCRIPTION
Hello Desmos! Since it's close to Valentine's Day, I was reminded of Mathograms, and I saw that it was open-source. I took a quick look at the code and realized that the link shortener had been stripped out and was never replaced.

Because the Google URL shortener is defunct, I replaced it with the TinyURL API. I've tried it out, and it appears to work seamlessly.

If you would like to view a demo of this code, you can see it [on Heroku](https://mathograms-zane.herokuapp.com/) (https://mathograms-zane.herokuapp.com/).

Thank you!